### PR TITLE
Update bunyan.js

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1103,7 +1103,7 @@ Logger.prototype.fatal = mkLogEmitter(FATAL);
 Logger.stdSerializers = {};
 
 // Serialize an HTTP request.
-Logger.stdSerializers.req = function req(req) {
+Logger.stdSerializers.req = function (req) {
     if (!req || !req.connection)
         return req;
     return {
@@ -1121,7 +1121,7 @@ Logger.stdSerializers.req = function req(req) {
 };
 
 // Serialize an HTTP response.
-Logger.stdSerializers.res = function res(res) {
+Logger.stdSerializers.res = function (res) {
     if (!res || !res.statusCode)
         return res;
     return {
@@ -1154,7 +1154,7 @@ function getFullErrorStack(ex)
 
 // Serialize an Error object
 // (Core error properties are enumerable in node 0.4, not in 0.6).
-var errSerializer = Logger.stdSerializers.err = function err(err) {
+var errSerializer = Logger.stdSerializers.err = function (err) {
     if (!err || !err.stack)
         return err;
     var obj = {


### PR DESCRIPTION
When in strict mode, some safari versions will issue a syntax error if a function has the same name as one of its variables.
This patch fixes this case by removing the function names.